### PR TITLE
bugfix: Set Version as Module Attribute for Release CI to Find

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.1] 2024-05-28
+
+Fix bug where `version` key needed to be set as module attribute `@version`
+for `sed` to find it.
+
 ## [0.1.0] - 2024-05-15
 
 Initial release.

--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,7 @@
 defmodule JsonSchemaNif.MixProject do
   use Mix.Project
 
+  @version "0.1.1"
   @project_url "https://github.com/podium/json_schema_nif"
 
   def project do
@@ -8,7 +9,7 @@ defmodule JsonSchemaNif.MixProject do
       app: :json_schema_nif,
       name: "JSON Schema NIF",
       description: "A JSON Schema Validator via NIF bindings to Rust",
-      version: "0.1.0",
+      version: @version,
       elixir: "~> 1.15",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/native/json_schema_nif/Cargo.toml
+++ b/native/json_schema_nif/Cargo.toml
@@ -2,7 +2,7 @@
   authors = []
   edition = "2021"
   name = "json_schema_nif"
-  version = "0.1.0"
+  version = "0.1.1"
 
 [lib]
   crate-type = ["cdylib", "lib"]


### PR DESCRIPTION
Test with `echo "PROJECT_VERSION=$(sed -n 's/^  @version "\(.*\)"/\1/p' mix.exs | head -n1)"` should generate properly. Tag 0.1.0 generated artifacts missing the version number, which makes them impossible for RustlerPrecompiled to find locally. The release.yml has a step that should interpolate it properly when set as module attribute.