### PR TITLE
Switch to `ubuntu-latest` for Deprecated ubuntu-20.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,30 +25,30 @@ jobs:
         job:
           - {
               target: arm-unknown-linux-gnueabihf,
-              os: ubuntu-20.04,
+              os: ubuntu-latest,
               use-cross: true,
             }
           - {
               target: aarch64-unknown-linux-gnu,
-              os: ubuntu-20.04,
+              os: ubuntu-latest,
               use-cross: true,
             }
           - {
               target: aarch64-unknown-linux-musl,
-              os: ubuntu-20.04,
+              os: ubuntu-latest,
               use-cross: true,
             }
           - { target: aarch64-apple-darwin, os: macos-latest }
           - {
               target: riscv64gc-unknown-linux-gnu,
-              os: ubuntu-20.04,
+              os: ubuntu-latest,
               use-cross: true,
             }
           - { target: x86_64-apple-darwin, os: macos-latest }
-          - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04 }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest }
           - {
               target: x86_64-unknown-linux-musl,
-              os: ubuntu-20.04,
+              os: ubuntu-latest,
               use-cross: true,
             }
           - { target: x86_64-pc-windows-gnu, os: windows-2019 }


### PR DESCRIPTION
Fixes issues where CI is breaking due to using 20.04 image. Compare to this PR where a bunch of jobs were cancelled: https://github.com/podium/json_schema_nif/actions/runs/14577899742