### PR TITLE
Update Windows Runners to Latest for 2019 Deprecation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,8 @@ jobs:
               os: ubuntu-latest,
               use-cross: true,
             }
-          - { target: x86_64-pc-windows-gnu, os: windows-2019 }
-          - { target: x86_64-pc-windows-msvc, os: windows-2019 }
+          - { target: x86_64-pc-windows-gnu, os: windows-2025 }
+          - { target: x86_64-pc-windows-msvc, os: windows-2025 }
 
     steps:
       - name: Checkout source code


### PR DESCRIPTION
`windows-2019` runners are being deprecated: https://github.com/actions/runner-images/issues/12045